### PR TITLE
composer update 2021-04-08

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1027,7 +1027,7 @@
         },
         {
             "name": "illuminate/broadcasting",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/broadcasting.git",
@@ -1083,7 +1083,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1136,7 +1136,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1193,7 +1193,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1247,7 +1247,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1295,7 +1295,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1355,7 +1355,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1406,7 +1406,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1454,7 +1454,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
@@ -1522,7 +1522,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1577,7 +1577,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1639,7 +1639,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",
@@ -1697,7 +1697,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1743,7 +1743,7 @@
         },
         {
             "name": "illuminate/mail",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/mail.git",
@@ -1804,7 +1804,7 @@
         },
         {
             "name": "illuminate/notifications",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/notifications.git",
@@ -1862,7 +1862,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1910,7 +1910,7 @@
         },
         {
             "name": "illuminate/queue",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
@@ -1975,7 +1975,7 @@
         },
         {
             "name": "illuminate/session",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/session.git",
@@ -2031,7 +2031,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -2099,7 +2099,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -2157,7 +2157,7 @@
         },
         {
             "name": "illuminate/view",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
@@ -7461,16 +7461,16 @@
         },
         {
             "name": "team-reflex/discord-php",
-            "version": "v5.1.2",
+            "version": "v5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/discord-php/DiscordPHP.git",
-                "reference": "f61603d42247e10da32d654a0d6b346f571b3aaa"
+                "reference": "83531277db436a9c054ec6f58f6c8c0e0823e156"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/discord-php/DiscordPHP/zipball/f61603d42247e10da32d654a0d6b346f571b3aaa",
-                "reference": "f61603d42247e10da32d654a0d6b346f571b3aaa",
+                "url": "https://api.github.com/repos/discord-php/DiscordPHP/zipball/83531277db436a9c054ec6f58f6c8c0e0823e156",
+                "reference": "83531277db436a9c054ec6f58f6c8c0e0823e156",
                 "shasum": ""
             },
             "require": {
@@ -7525,9 +7525,9 @@
             "description": "An unofficial API to interact with the voice and text service Discord.",
             "support": {
                 "issues": "https://github.com/discord-php/DiscordPHP/issues",
-                "source": "https://github.com/discord-php/DiscordPHP/tree/v5.1.2"
+                "source": "https://github.com/discord-php/DiscordPHP/tree/v5.1.3"
             },
-            "time": "2021-03-02T05:53:18+00:00"
+            "time": "2021-04-07T09:01:13+00:00"
         },
         {
             "name": "textalk/websocket",


### PR DESCRIPTION
  - Upgrading illuminate/broadcasting (v8.36.1 => v8.36.2)
  - Upgrading illuminate/bus (v8.36.1 => v8.36.2)
  - Upgrading illuminate/cache (v8.36.1 => v8.36.2)
  - Upgrading illuminate/collections (v8.36.1 => v8.36.2)
  - Upgrading illuminate/config (v8.36.1 => v8.36.2)
  - Upgrading illuminate/console (v8.36.1 => v8.36.2)
  - Upgrading illuminate/container (v8.36.1 => v8.36.2)
  - Upgrading illuminate/contracts (v8.36.1 => v8.36.2)
  - Upgrading illuminate/database (v8.36.1 => v8.36.2)
  - Upgrading illuminate/events (v8.36.1 => v8.36.2)
  - Upgrading illuminate/filesystem (v8.36.1 => v8.36.2)
  - Upgrading illuminate/http (v8.36.1 => v8.36.2)
  - Upgrading illuminate/macroable (v8.36.1 => v8.36.2)
  - Upgrading illuminate/mail (v8.36.1 => v8.36.2)
  - Upgrading illuminate/notifications (v8.36.1 => v8.36.2)
  - Upgrading illuminate/pipeline (v8.36.1 => v8.36.2)
  - Upgrading illuminate/queue (v8.36.1 => v8.36.2)
  - Upgrading illuminate/session (v8.36.1 => v8.36.2)
  - Upgrading illuminate/support (v8.36.1 => v8.36.2)
  - Upgrading illuminate/testing (v8.36.1 => v8.36.2)
  - Upgrading illuminate/view (v8.36.1 => v8.36.2)
  - Upgrading team-reflex/discord-php (v5.1.2 => v5.1.3)
